### PR TITLE
chore: Fix typo on db migrate command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Note: to test the plugin locally, see [CONTRIBUTING.md](CONTRIBUTING.md)
 8. Create and execute database migrations:
 
        bin/console doctrine:migrations:diff
-       bin/console bin/console doctrine:migrations:migrate
+       bin/console doctrine:migrations:migrate
 
 9. Copy the assets
 


### PR DESCRIPTION
Hey there, just a quick typo fix.