### PR TITLE
Do not validate if the shipping method is not click and collect

### DIFF
--- a/src/Validator/Constraints/SlotAvailableValidator.php
+++ b/src/Validator/Constraints/SlotAvailableValidator.php
@@ -51,6 +51,10 @@ final class SlotAvailableValidator extends ConstraintValidator
             throw new UnexpectedValueException($value, ClickNCollectShipmentInterface::class);
         }
 
+        if ((null === $method = $value->getMethod()) || !$method->isClickNCollect()) {
+            return;
+        }
+
         if (null === $collectionTime = $value->getCollectionTime()) {
             return;
         }


### PR DESCRIPTION
The validation is always happening, even if the shipping method is not Click and Collect.

Fixing this behavior.

