### PR TITLE
Fix Sylius version to 1.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.4",
         "simshaun/recurr": "^4.0",
-        "sylius/sylius": "^1.7",
+        "sylius/sylius": "<1.8",
         "symfony/lock": "^4.4 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Avoid using Sylius 1.8.* while not compatible (see [DoctribeMigrationBundle issue when upgrading from 2.* to 3.*](https://github.com/doctrine/DoctrineMigrationsBundle/issues/338))