### PR TITLE
Improve filtering of shipments

### DIFF
--- a/src/EventListener/ShipmentCollectionTimeLockListener.php
+++ b/src/EventListener/ShipmentCollectionTimeLockListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CoopTilleuls\SyliusClickNCollectPlugin\EventListener;
 
 use CoopTilleuls\SyliusClickNCollectPlugin\Entity\ClickNCollectShipmentInterface;
+use CoopTilleuls\SyliusClickNCollectPlugin\Entity\ClickNCollectShippingMethodInterface;
 use CoopTilleuls\SyliusClickNCollectPlugin\Repository\CollectionTimeRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
@@ -83,7 +84,12 @@ final class ShipmentCollectionTimeLockListener
 
         $filteredShipments = [];
         foreach ($order->getShipments() as $shipment) {
-            if ($shipment instanceof ClickNCollectShipmentInterface && null !== $shipment->getCollectionTime()) {
+            if (
+                $shipment instanceof ClickNCollectShipmentInterface
+                && null !== $shipment->getCollectionTime()
+                && $shipment->getMethod() instanceof ClickNCollectShippingMethodInterface
+                && $shipment->getMethod()->isClickNCollect()
+            ) {
                 $filteredShipments[] = $shipment;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | related to #31, closes #30

We want shipments with a Click and Collect shipping method.

Having a Collection Time doesn't make a shipment eligible. If you select a collection time, get an error, then the shipment will still have that collection time.
Then if you change to another shipping method it will fail.
