### PR TITLE
Use jsdelivr as CDN instead of unpkg

### DIFF
--- a/src/Resources/views/fullcalendar/_scripts.html.twig
+++ b/src/Resources/views/fullcalendar/_scripts.html.twig
@@ -1,5 +1,5 @@
 {# TODO: use a local installation and Webpack Encore, need https://github.com/Sylius/Sylius/issues/10656 #}
-{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://unpkg.com/@fullcalendar/core@^4/locales-all.js'} %}
-{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://unpkg.com/@fullcalendar/core@^4/main.js'} %}
-{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://unpkg.com/@fullcalendar/daygrid@^4/main.js'} %}
-{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://unpkg.com/@fullcalendar/timegrid@^4/main.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://cdn.jsdelivr.net/npm/@fullcalendar/core@^4/locales-all.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://cdn.jsdelivr.net/npm/@fullcalendar/core@^4/main.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@^4/main.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@^4/main.js'} %}

--- a/src/Resources/views/fullcalendar/_styles.html.twig
+++ b/src/Resources/views/fullcalendar/_styles.html.twig
@@ -1,4 +1,4 @@
 {# TODO: use a local installation and Webpack Encore, need https://github.com/Sylius/Sylius/issues/10656 #}
-{% include '@SyliusUi/_stylesheets.html.twig' with {'path': 'https://unpkg.com/@fullcalendar/core@^4/main.css'} %}
-{% include '@SyliusUi/_stylesheets.html.twig' with {'path': 'https://unpkg.com/@fullcalendar/daygrid@^4/main.css'} %}
-{% include '@SyliusUi/_stylesheets.html.twig' with {'path': 'https://unpkg.com/@fullcalendar/timegrid@^4/main.css'} %}
+{% include '@SyliusUi/_stylesheets.html.twig' with {'path': 'https://cdn.jsdelivr.net/npm/@fullcalendar/core@^4/main.css'} %}
+{% include '@SyliusUi/_stylesheets.html.twig' with {'path': 'https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@^4/main.css'} %}
+{% include '@SyliusUi/_stylesheets.html.twig' with {'path': 'https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@^4/main.css'} %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kind of :p
| New feature?  | no
| Deprecations? | yo
| Tickets       |

unpkg is slower than jsdeliver :) Like really faster. We are talking about avoiding a redirect which takes 300ms per file.
