### PR TITLE
fix: use Doctrine EntityManagerInterface instead of ObjectManager

### DIFF
--- a/src/Fixture/Factory/OrderExampleFactory.php
+++ b/src/Fixture/Factory/OrderExampleFactory.php
@@ -15,7 +15,7 @@ namespace CoopTilleuls\SyliusClickNCollectPlugin\Fixture\Factory;
 
 use CoopTilleuls\SyliusClickNCollectPlugin\CollectionTime\AvailableSlotsComputerInterface;
 use CoopTilleuls\SyliusClickNCollectPlugin\Entity\ClickNCollectShipmentInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\OrderExampleFactory as BaseOrderExampleFactory;
 use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
@@ -35,7 +35,7 @@ class OrderExampleFactory extends BaseOrderExampleFactory
 {
     private AvailableSlotsComputerInterface $availableSlotsComputer;
 
-    public function __construct(FactoryInterface $orderFactory, FactoryInterface $orderItemFactory, OrderItemQuantityModifierInterface $orderItemQuantityModifier, ObjectManager $orderManager, RepositoryInterface $channelRepository, RepositoryInterface $customerRepository, ProductRepositoryInterface $productRepository, RepositoryInterface $countryRepository, PaymentMethodRepositoryInterface $paymentMethodRepository, ShippingMethodRepositoryInterface $shippingMethodRepository, FactoryInterface $addressFactory, StateMachineFactoryInterface $stateMachineFactory, OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker, OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker, AvailableSlotsComputerInterface $availableSlotsComputer)
+    public function __construct(FactoryInterface $orderFactory, FactoryInterface $orderItemFactory, OrderItemQuantityModifierInterface $orderItemQuantityModifier, EntityManagerInterface $orderManager, RepositoryInterface $channelRepository, RepositoryInterface $customerRepository, ProductRepositoryInterface $productRepository, RepositoryInterface $countryRepository, PaymentMethodRepositoryInterface $paymentMethodRepository, ShippingMethodRepositoryInterface $shippingMethodRepository, FactoryInterface $addressFactory, StateMachineFactoryInterface $stateMachineFactory, OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker, OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker, AvailableSlotsComputerInterface $availableSlotsComputer)
     {
         parent::__construct($orderFactory, $orderItemFactory, $orderItemQuantityModifier, $orderManager, $channelRepository, $customerRepository, $productRepository, $countryRepository, $paymentMethodRepository, $shippingMethodRepository, $addressFactory, $stateMachineFactory, $orderShippingMethodSelectionRequirementChecker, $orderPaymentMethodSelectionRequirementChecker);
         $this->availableSlotsComputer = $availableSlotsComputer;


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | fixes #57 <!-- prefix each issue number with "fixes #", if any -->

The service `sylius.manager.order` is already an instance of [`Doctrine\ORM\EntityManager` which already implement `Doctrine\ORM\EntityManagerInterface`](https://github.com/doctrine/orm/blob/2.8.x/lib/Doctrine/ORM/EntityManager.php#L80), so everything will be fine I guess:
![image](https://user-images.githubusercontent.com/2103975/112451755-22792280-8d56-11eb-96c5-3f4bc3139db6.png)

**EDIT:** not sure why the CI is failing, maybe the runner run with PHP 8.x by default and it fails due to [this constraint](https://github.com/coopTilleuls/CoopTilleulsSyliusClickNCollectPlugin/blob/master/composer.json#L8).